### PR TITLE
Add env vars to control timeouts of analyze & vacuums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Don't check in vendor. I like clean code reviews
 vendor/
+
+# Code coverage
+coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ notifications:
 
 script:
 - go build ./cmd/pg-dba/...
-- go test -v -tags=integration -coverprofile=coverage.txt -covermode=atomic ./pkg/dba/... # Run integration tests
+- make integration-tests
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ docker-image:
 			    -t jonstacks/pg-dba:latest \
 			    --build-arg PG_DBA_VERSION=$(VERSION) .
 
+unit-tests:
+	go test -v -coverprofile=coverage.txt -covermode=atomic ./...
+
+integration-tests:
+	go test -v -tags=integration -coverprofile=coverage.txt -covermode=atomic ./...
+
 doc-server:
 	$(MAKE) -C docs doc-server
 

--- a/cmd/pg-dba/main.go
+++ b/cmd/pg-dba/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/jonstacks/pg-dba/pkg/config"
 	"github.com/jonstacks/pg-dba/pkg/dba"
@@ -22,7 +23,20 @@ func init() {
 }
 
 func main() {
+
+	analyzeTimeoutSecs, err := config.AnalyzeTimeoutSeconds()
+	fatal(err)
+
+	vacuumTimeoutSecs, err := config.VacuumTimeoutSeconds()
+	fatal(err)
+
+	fullVacuumTimeoutSecs, err := config.FullVacuumTimeoutSeconds()
+	fatal(err)
+
 	opts := dba.NewDefaultOptions()
+	opts.AnalyzeTimeout = time.Duration(analyzeTimeoutSecs) * time.Second
+	opts.VacuumTimout = time.Duration(vacuumTimeoutSecs) * time.Second
+	opts.FullVacuumTimeout = time.Duration(fullVacuumTimeoutSecs)
 	opts.Verbose = config.Verbose()
 	admin := dba.New(config.DBConnectionString(), opts)
 	fatal(admin.Run())

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,7 +1,7 @@
 
 doc-server:
 	@docker build -t pg-dba-hugo .
-	@docker run -d -p "1313:1313" -v $(PWD):/doc --name pg-dba-docs pg-dba-hugo
+	@docker run -d -p "1313:1313" -v $$(pwd):/doc --name pg-dba-docs pg-dba-hugo
 	sleep 2 # Wait for doc server to come up
 	open http://localhost:1313/pg-dba/
 

--- a/docs/content/configuration/_index.md
+++ b/docs/content/configuration/_index.md
@@ -15,14 +15,17 @@ Below is a list of the environment variables, their defaults, descriptions,
 and allowed values:
 
 
-| Environment Variable  | Default Value | Description                                   | Allowed Values                                                            |
-|-----------------------|---------------|-----------------------------------------------|---------------------------------------------------------------------------|
-| POSTGRES_DB           | postgres      | The postgres DB                               | `*`                                                                       |
-| POSTGRES_HOST         | localhost     | The postgres host                             | `*`                                                                       |
-| POSTGRES_PASSWORD     | ""            | The postgres password                         | `*`                                                                       |
-| POSTGRES_USER         | postgres      | The postgres user                             | `*`                                                                       |
-| LOG_LEVEL             | info          | The level to output logs at                   | debug, info, warn, error                                                  |
-| POST_ANALYZE          | True          | Run an analyze after vacuum to update stats   | True, False                                                               |
-| PRE_ANALYZE           | True          | Run an analyze to update stats before vacuum  | True, False                                                               |
-| SSL_MODE              | require       | SSLMode for the connection.                   | See https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters  |
-| VERBOSE               | False         | Run queries in VERBOSE mode                   | True, False                                                               |
+| Environment Variable        | Default Value | Description                                       | Allowed Values                                                            |
+|-----------------------------|---------------|---------------------------------------------------|---------------------------------------------------------------------------|
+| ANALYZE_TIMEOUT_SECONDS     | 600           | The time in seconds before stopping an analyze    | Integer greater than 0                                                    |
+| FULL_VACUUM_TIMEOUT_SECONDS | 600           | The time in seconds before stopping a full vacuum | Integer greater than 0                                                    |
+| POSTGRES_DB                 | postgres      | The postgres DB                                   | `*`                                                                       |
+| POSTGRES_HOST               | localhost     | The postgres host                                 | `*`                                                                       |
+| POSTGRES_PASSWORD           | ""            | The postgres password                             | `*`                                                                       |
+| POSTGRES_USER               | postgres      | The postgres user                                 | `*`                                                                       |
+| LOG_LEVEL                   | info          | The level to output logs at                       | debug, info, warn, error                                                  |
+| POST_ANALYZE                | True          | Run an analyze after vacuum to update stats       | True, False                                                               |
+| PRE_ANALYZE                 | True          | Run an analyze to update stats before vacuum      | True, False                                                               |
+| SSL_MODE                    | require       | SSLMode for the connection.                       | See https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters  |
+| VERBOSE                     | False         | Run queries in VERBOSE mode                       | True, False                                                               |
+| VACUUM_TIMEOUT_SECONDS      | 600           | The time in seconds before stopping a vacuum      | Integer greater than 0                                                    |

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,10 @@ module github.com/jonstacks/pg-dba
 go 1.12
 
 require (
+	github.com/davecgh/go-spew v1.1.1
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
 	github.com/lib/pq v1.0.0
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/sirupsen/logrus v1.1.1
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -29,6 +30,20 @@ func envDefault(name, defaultValue string) string {
 
 func lowerEnvDefault(name, defaultValue string) string {
 	return strings.ToLower(envDefault(name, defaultValue))
+}
+
+func envInt(name string, defaultValue int) (int, error) {
+	val := os.Getenv(name)
+	if val == "" {
+		return defaultValue, nil
+	}
+	return strconv.Atoi(val)
+}
+
+// AnalyzeTimeoutSeconds returns the number of seconds of how long pg-dba will
+// wait for an Analyze operation on the DB.
+func AnalyzeTimeoutSeconds() (int, error) {
+	return envInt("ANALYZE_TIMEOUT_SECONDS", 600)
 }
 
 // DBConnectionString forms & returns the DBConnectionString
@@ -60,6 +75,12 @@ func DBPassword() string {
 // DBUser returns the POSTGRES_USER if exists, otherwise postgres
 func DBUser() string {
 	return envDefault("POSTGRES_USER", "postgres")
+}
+
+// FullVacuumTimeoutSeconds returns the number of seconds of how long pg-dba will
+// wait for an Analyze operation on the DB.
+func FullVacuumTimeoutSeconds() (int, error) {
+	return envInt("FULL_VACUUM_TIMEOUT_SECONDS", 600)
 }
 
 // LogFormat returns a logrus.Formatter that can be used to configure the
@@ -104,6 +125,12 @@ func PreAnalyze() bool {
 // See https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters
 func SSLMode() string {
 	return envDefault("SSL_MODE", "require")
+}
+
+// VacuumTimeoutSeconds returns the number of seconds of how long pg-dba will
+// wait for a Vacuum operation on the DB.
+func VacuumTimeoutSeconds() (int, error) {
+	return envInt("VACUUM_TIMEOUT_SECONDS", 600)
 }
 
 // Verbose returns whether or not we should run queries in verbose mode.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func withEnvSet(key, value string, f func(key string)) {
+	os.Setenv(key, value)
+	f(key)
+	os.Unsetenv(key)
+}
+
+func TestEnvBool(t *testing.T) {
+	withEnvSet("BOOLEAN_KEY", "wrong", func(key string) {
+		val := envBool(key, true)
+		assert.False(t, val)
+
+		val = envBool(key, false)
+		assert.False(t, val)
+	})
+
+	withEnvSet("BOOLEAN_KEY", "TRUE", func(key string) {
+		val := envBool(key, false)
+		assert.True(t, val)
+
+		val = envBool(key, true)
+		assert.True(t, val)
+	})
+
+	// No Value set
+	val := envBool("BOOLEAN_KEY", false)
+	assert.False(t, val)
+
+	val = envBool("BOOLEAN_KEY", true)
+	assert.True(t, val)
+}
+
+func TestEnvInt(t *testing.T) {
+	withEnvSet("MYINT", "10000", func(key string) {
+		val, err := envInt(key, 3000)
+		assert.NoError(t, err)
+		assert.Equal(t, 10000, val)
+	})
+
+	withEnvSet("MYINT", "", func(key string) {
+		val, err := envInt(key, 1000)
+		assert.NoError(t, err)
+		assert.Equal(t, 1000, val)
+	})
+}

--- a/pkg/dba/dba_integration_test.go
+++ b/pkg/dba/dba_integration_test.go
@@ -4,6 +4,7 @@ package dba
 
 import (
 	"testing"
+	"time"
 
 	"github.com/jonstacks/pg-dba/pkg/config"
 	"github.com/stretchr/testify/assert"
@@ -15,4 +16,19 @@ func TestDBACase1(t *testing.T) {
 	opts.Verbose = config.Verbose()
 	dba := New(config.DBConnectionString(), opts)
 	assert.Nil(t, dba.Run())
+}
+
+func TestDBANonVerbose(t *testing.T) {
+	opts := NewDefaultOptions()
+	opts.Verbose = false
+	dba := New(config.DBConnectionString(), opts)
+	assert.Nil(t, dba.Run())
+}
+
+func TestDBATimeout(t *testing.T) {
+	opts := NewDefaultOptions()
+	opts.AnalyzeTimeout = 50 * time.Millisecond
+	opts.Verbose = config.Verbose()
+	dba := New(config.DBConnectionString(), opts)
+	assert.Error(t, dba.Run())
 }


### PR DESCRIPTION
This will allow the end user greater flexibility in how pg-dba runs.

Fixes #7 